### PR TITLE
Use assert only for should never happen case

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -139,7 +139,7 @@ contract DutchAuction {
         Setup();
 
         // Tei auctioned
-        assert(tokens_auctioned > multiplier);
+        require(tokens_auctioned > multiplier);
     }
 
     /// @notice Set `_price_factor` and `_price_const` as the new price factor
@@ -247,7 +247,7 @@ contract DutchAuction {
         // Set receiver bid to 0 before assigning tokens
         bids[receiver] = 0;
 
-        assert(token.transfer(receiver, num));
+        require(token.transfer(receiver, num));
 
         ClaimedTokens(receiver, num);
 

--- a/contracts/token.sol
+++ b/contracts/token.sol
@@ -91,7 +91,7 @@ contract StandardToken is Token {
         public
         returns (bool)
     {
-        assert(transfer(_to, _value));
+        require(transfer(_to, _value));
 
         uint codeLength;
 


### PR DESCRIPTION
As per the [docs](http://solidity.readthedocs.io/en/develop/control-structures.html?highlight=require#error-handling-assert-require-revert-and-exceptions) `assert` should only be used for things that should never happen.

If it's something that depends on user input or on return of external
function calls then `require` should be called.