### PR TITLE
Add wallet for keeping all the ETH

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -106,7 +106,7 @@ contract DutchAuction {
 
     /// @dev Contract constructor function sets price factor and constant for
     /// calculating the Dutch Auction price.
-    /// @param _wallet Wallet address for contributed ETH.
+    /// @param _wallet Wallet address to which all contributed ETH will be forwarded.
     /// @param _price_factor Auction price factor.
     /// @param _price_const Auction price divisor constant.
     function DutchAuction(address _wallet, uint _price_factor, uint _price_const) public {


### PR DESCRIPTION
Closes https://github.com/raiden-network/raiden-token/issues/54

All received ETH from the bids will be sent to this wallet. So no ETH will be lost / frozen in the auction contract if something goes wrong.

- removed `TradingStarted` event
- removed `transferFundsToOwner`
- removed `missingFundsToEndAuction(funds)`  (only `missingFundsToEndAuction`)