### PR TITLE
Remove useless check.

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -141,9 +141,6 @@ contract DutchAuction {
 
         stage = Stages.AuctionSetUp;
         Setup();
-
-        // Tei auctioned
-        require(tokens_auctioned > multiplier);
     }
 
     /// @notice Set `_price_factor` and `_price_const` as the new price factor


### PR DESCRIPTION
Closes https://github.com/raiden-network/raiden-token/issues/63

Remove check:
https://github.com/raiden-network/raiden-token/blob/708de0f947ea3fe9ba83bd3f2b7c9d813204c397/contracts/auction.sol#L146

Because we already have:
https://github.com/raiden-network/raiden-token/blob/ac8eb30833b9a2996a1117b93befa1e870740cf7/contracts/token.sol#L228

This check is put in place so we don't forget that the initial supply of tokens should be given in token fractions `Tei = TKN * multiplier` and not in `TKN`