### PR TITLE
Token burn() - add a Transfer event to 0x0

### DIFF
--- a/contracts/token.sol
+++ b/contracts/token.sol
@@ -275,6 +275,7 @@ contract CustomToken is StandardToken {
         balances[msg.sender] -= num;
         totalSupply -= num;
         Burnt(msg.sender, num, totalSupply);
+        Transfer(msg.sender, 0x0, num);
 
         assert(balances[msg.sender] == pre_balance - num);
     }


### PR DESCRIPTION
We want to see these events in Etherscan, so we will also add a Transfer event to 0x0.

Closes https://github.com/raiden-network/raiden-token/issues/71