### PR TITLE
Remove SettingsChanged event

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -96,11 +96,6 @@ contract DutchAuction {
         uint32 indexed _price_exponent
     );
     event Setup();
-    event SettingsChanged(
-        uint indexed _price_start,
-        uint indexed _price_constant,
-        uint32 indexed _price_exponent
-    );
     event AuctionStarted(uint indexed _start_time, uint indexed _block_number);
     event BidSubmission(
         address indexed _sender,
@@ -179,7 +174,6 @@ contract DutchAuction {
         price_start = _price_start;
         price_constant = _price_constant;
         price_exponent = _price_exponent;
-        SettingsChanged(price_start, price_constant, price_exponent);
     }
 
     /// @notice Start the auction.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -134,7 +134,6 @@ def auction_contract(
     if print_the_logs:
         print_logs(auction_contract, 'Deployed', auction_contract_type)
         print_logs(auction_contract, 'Setup', auction_contract_type)
-        print_logs(auction_contract, 'SettingsChanged', auction_contract_type)
         print_logs(auction_contract, 'AuctionStarted', auction_contract_type)
         print_logs(auction_contract, 'BidSubmission', auction_contract_type)
         print_logs(auction_contract, 'AuctionEnded', auction_contract_type)
@@ -160,7 +159,6 @@ def auction_contract_fast_decline(
     if print_the_logs:
         print_logs(auction_contract, 'Deployed', auction_contract_type)
         print_logs(auction_contract, 'Setup', auction_contract_type)
-        print_logs(auction_contract, 'SettingsChanged', auction_contract_type)
         print_logs(auction_contract, 'AuctionStarted', auction_contract_type)
         print_logs(auction_contract, 'BidSubmission', auction_contract_type)
         print_logs(auction_contract, 'AuctionEnded', auction_contract_type)


### PR DESCRIPTION
Not needed anymore, because `changeSettings` is an internal function called in the constructor.
The `Deployed` event already contains the auction parameters.