### PR TITLE
Prevent token&auction address to be used in bid()

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -227,6 +227,8 @@ contract DutchAuction {
         atStage(Stages.AuctionStarted)
     {
         require(receiver_address != 0x0);
+        require(receiver_address != address(this));
+        require(receiver_address != address(token));
         require(msg.value > 0);
         assert(bids[receiver_address] + msg.value >= msg.value);
 

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -255,6 +255,13 @@ def test_auction_bid(
     token_multiplier = auction.call().token_multiplier()
 
     auction.transact({'from': owner}).startAuction()
+    # Bids with the token contract address as receiver should fail
+    with pytest.raises(tester.TransactionFailed):
+        auction.transact({'from': A, "value": 100}).bid(token.address)
+
+    # Bids with the auction contract address as receiver should fail
+    with pytest.raises(tester.TransactionFailed):
+        auction.transact({'from': A, "value": 100}).bid(auction.address)
 
     # End auction by bidding the needed amount
     missing_funds = auction.call().missingFundsToEndAuction()


### PR DESCRIPTION
Closes https://github.com/raiden-network/raiden-token/issues/91
Token and auction contract addresses should not be used as receivers of tokens.