### PR TITLE
Remove owner and Distributed event from Distributor

### DIFF
--- a/contracts/distributor.sol
+++ b/contracts/distributor.sol
@@ -10,25 +10,11 @@ contract Distributor {
 
     DutchAuction public auction;
 
-    // TODO The owner can be removed
-    // Anyone should be able to claim tokens
-    address public owner;
-
-    /*
-     * Modifiers
-     */
-
-    modifier isOwner() {
-        require(msg.sender == owner);
-        _;
-    }
-
     /*
      * Events
      */
 
     event Deployed();
-    event Distributed(address[] indexed addresses);
 
     /*
       * Public functions
@@ -38,21 +24,18 @@ contract Distributor {
     function Distributor(address _auction_address) public {
         require(_auction_address != 0x0);
 
-        owner = msg.sender;
         auction = DutchAuction(_auction_address);
-        require(auction.owner_address() == owner);
         Deployed();
     }
 
     /// @notice Claim tokens in behalf of the following token owners: `addresses`.
     /// @dev Function that is called with an array of addresses for claiming tokens in their behalf.
     /// @param addresses Addresses of auction bidders that will be assigned tokens.
-    function distribute(address[] addresses) public isOwner {
-        for (uint8 i = 0; i < addresses.length; i++) {
+    function distribute(address[] addresses) public {
+        for (uint32 i = 0; i < addresses.length; i++) {
             if (auction.bids(addresses[i]) > 0) {
                 auction.claimTokens(addresses[i]);
             }
         }
-        Distributed(addresses);
     }
 }

--- a/tests/test_distributor.py
+++ b/tests/test_distributor.py
@@ -67,9 +67,8 @@ def test_distributor_init(
     with pytest.raises(TypeError):
         create_contract(Distributor, [0x0])
 
-    # Fail if auction has another owner
-    with pytest.raises(tester.TransactionFailed):
-        create_contract(Distributor, [other_owner_auction.address])
+    # Distributor contract can have any owner
+    create_contract(Distributor, [other_owner_auction.address])
 
     distributor_contract = create_contract(Distributor, [auction.address])
 


### PR DESCRIPTION
Closes https://github.com/raiden-network/raiden-token/issues/88

- remove `owner` (not needed, as anyone can call `auction.claimTokens`)
- remove `Distributed` event
- change `i` from `uint8` to `uint32`