### PR TITLE
Rename overloaded functions

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -248,13 +248,13 @@ contract DutchAuction {
     /// @dev Claims tokens for `msg.sender` after auction. To be used if tokens can
     /// be claimed by beneficiaries, individually.
     function claimTokens() public atStage(Stages.AuctionEnded) returns (bool) {
-        return claimTokens(msg.sender);
+        return proxyClaimTokens(msg.sender);
     }
 
     /// @notice Claim auction tokens for `receiver_address` after the auction has ended.
     /// @dev Claims tokens for `receiver_address` after auction has ended.
     /// @param receiver_address Tokens will be assigned to this address if eligible.
-    function claimTokens(address receiver_address)
+    function proxyClaimTokens(address receiver_address)
         public
         atStage(Stages.AuctionEnded)
         returns (bool)

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -208,14 +208,14 @@ contract DutchAuction {
     /// @notice Send `msg.value` WEI to the auction from the `msg.sender` account.
     /// @dev Allows to send a bid to the auction.
     function bid() public payable atStage(Stages.AuctionStarted) {
-        bid(msg.sender);
+        proxyBid(msg.sender);
     }
 
     /// @notice Send `msg.value` WEI to the auction from the `msg.sender` account
     /// and the `receiver` account will receive the tokens if claimed.
     /// @dev Allows to send a bid to the auction.
     /// @param receiver_address Token receiver account address.
-    function bid(address receiver_address)
+    function proxyBid(address receiver_address)
         public
         payable
         atStage(Stages.AuctionStarted)

--- a/contracts/distributor.sol
+++ b/contracts/distributor.sol
@@ -34,7 +34,7 @@ contract Distributor {
     function distribute(address[] addresses) public {
         for (uint32 i = 0; i < addresses.length; i++) {
             if (auction.bids(addresses[i]) > 0) {
-                auction.claimTokens(addresses[i]);
+                auction.proxyClaimTokens(addresses[i]);
             }
         }
     }

--- a/tests/auction_fixtures.py
+++ b/tests/auction_fixtures.py
@@ -229,7 +229,7 @@ def auction_claim_tokens_tested(web3, owner, contract_params):
 
         if len(bidders) == 1:
             txn_hash = auction.transact({'from': bidders[0]}).claimTokens()
-            # auction.transact({'from': owner}).claimTokens(bidders[0])
+            # auction.transact({'from': owner}).proxyClaimTokens(bidders[0])
         else:
             txn_hash = distributor.transact({'from': owner}).distribute(bidders)
 

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -297,11 +297,11 @@ def test_auction_bid(
 
     # Bids with the token contract address as receiver should fail
     with pytest.raises(tester.TransactionFailed):
-        auction.transact({'from': A, "value": 100}).bid(token.address)
+        auction.transact({'from': A, "value": 100}).proxyBid(token.address)
 
     # Bids with the auction contract address as receiver should fail
     with pytest.raises(tester.TransactionFailed):
-        auction.transact({'from': A, "value": 100}).bid(auction.address)
+        auction.transact({'from': A, "value": 100}).proxyBid(auction.address)
 
     missing_funds = auction.call().missingFundsToEndAuction()
 


### PR DESCRIPTION
When using `bid()` from the console and providing an argument the proper `bid(address)` function was not used.

By inputting: `auction.bid("0x8b078c9a56caffa9d354d141f7f31abaac69b594", {from:eth.accounts[0], gas: 1000000, gasPrice: 180000000000, value: web3.toWei(2200)})` as an example the bid was not made in the name of `0x8b078c9a56caffa9d354d141f7f31abaac69b594` but still for `eth.accounts[0]`.

The fact that such sneaky behaviour can happen is terrible. For ways to force the correct function check [here](https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-methods).

Since having overloaded functions with the same name provides 0 usability benefits this is a no-brainer change.