### PR TITLE
Fix claimTokens for the last person claiming (rounding errors)

### DIFF
--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -270,7 +270,12 @@ contract DutchAuction {
         }
 
         // Number of Rei = bid_wei / Rei = bid_wei / (wei_per_RDN * token_multiplier)
-        uint num = token_multiplier * bids[receiver_address] / final_price;
+        uint num = (token_multiplier * bids[receiver_address]) / final_price;
+
+        uint auction_tokens_balance = token.balanceOf(address(this));
+        if(num > auction_tokens_balance) {
+            num = auction_tokens_balance;
+        }
 
         // Update the total amount of funds for which tokens have been claimed
         funds_claimed += bids[receiver_address];

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -272,6 +272,9 @@ contract DutchAuction {
         // Number of Rei = bid_wei / Rei = bid_wei / (wei_per_RDN * token_multiplier)
         uint num = (token_multiplier * bids[receiver_address]) / final_price;
 
+        // Due to final_price floor rounding, the number of assigned tokens may be higher
+        // than expected. Therefore, the number of remaining unassigned auction tokens
+        // may be smaller than the number of tokens needed for the last claimTokens call
         uint auction_tokens_balance = token.balanceOf(address(this));
         if(num > auction_tokens_balance) {
             num = auction_tokens_balance;

--- a/contracts/auction.sol
+++ b/contracts/auction.sol
@@ -276,7 +276,7 @@ contract DutchAuction {
         // than expected. Therefore, the number of remaining unassigned auction tokens
         // may be smaller than the number of tokens needed for the last claimTokens call
         uint auction_tokens_balance = token.balanceOf(address(this));
-        if(num > auction_tokens_balance) {
+        if (num > auction_tokens_balance) {
             num = auction_tokens_balance;
         }
 


### PR DESCRIPTION
Last call to `claimTokens` can fail if the rounding difference for the `final_price` calculation is big enough.
This means a smaller `final_price` -> more claimed tokens for everyone before the last claim (rounding).
Last `claimTokens` transaction fails because the auction contract has less tokens than expected.